### PR TITLE
[Ex12] fix docker-compose version

### DIFF
--- a/exercise12/docker-compose.yml
+++ b/exercise12/docker-compose.yml
@@ -1,4 +1,4 @@
-version: "2"
+version: "2.4"
 
 services:
 


### PR DESCRIPTION
The `platform` parameter was only added in version 2.4. Currently running `docker-compose up` gives
```
ERROR: The Compose file './docker-compose.yml' is invalid because:
Unsupported config option for services.neo4j: 'platform'
```